### PR TITLE
Fix toggling DAG suspension for DAGs with custom names

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"syscall"
 
@@ -284,7 +285,7 @@ func (e *client) GetStatus(id string) (*DAGStatus, error) {
 	}
 	latestStatus, _ := e.GetLatestStatus(dg)
 	return newDAGStatus(
-		dg, latestStatus, e.IsSuspended(dg.Name), err,
+		dg, latestStatus, e.IsSuspended(id), err,
 	), err
 }
 
@@ -295,8 +296,13 @@ func (e *client) ToggleSuspend(id string, suspend bool) error {
 
 func (e *client) readStatus(workflow *dag.DAG) (*DAGStatus, error) {
 	latestStatus, err := e.GetLatestStatus(workflow)
+	id := strings.TrimSuffix(
+		filepath.Base(workflow.Location),
+		filepath.Ext(workflow.Location),
+	)
+
 	return newDAGStatus(
-		workflow, latestStatus, e.IsSuspended(workflow.Name), err,
+		workflow, latestStatus, e.IsSuspended(id), err,
 	), err
 }
 

--- a/internal/scheduler/entryreader.go
+++ b/internal/scheduler/entryreader.go
@@ -75,7 +75,12 @@ func (er *entryReaderImpl) Read(now time.Time) ([]*entry, error) {
 	}
 
 	for _, workflow := range er.dags {
-		if er.client.IsSuspended(workflow.Name) {
+		id := strings.TrimSuffix(
+			filepath.Base(workflow.Location),
+			filepath.Ext(workflow.Location),
+		)
+
+		if er.client.IsSuspended(id) {
 			continue
 		}
 		addEntriesFn(workflow, workflow.Schedule, entryTypeStart)

--- a/ui/src/components/molecules/LiveSwitch.tsx
+++ b/ui/src/components/molecules/LiveSwitch.tsx
@@ -40,7 +40,7 @@ function LiveSwitch({ DAG, refresh, inputProps }: Props) {
     const enabled = !checked;
     setChecked(enabled);
     onSubmit({
-      name: DAG.DAG.Name,
+      name: DAG.File.replace(/.yaml$/, ''),
       action: 'suspend',
       value: enabled ? 'false' : 'true',
     });


### PR DESCRIPTION
I find that toggling DAG suspension (i.e. "live") from frontend doesn't work when the DAG has a custom name defined:

<img width="1728" alt="Screenshot 2024-07-29 at 8 06 11 PM" src="https://github.com/user-attachments/assets/3d618f1c-c31d-48db-9ee2-d5d175aec9c1">

Similar to #625, the frontend fix is extracting the file basename with out the `.yaml` bit as the DAG ID, and pass that to the backend for toggling.

However, upon fruther inspection, I also found the backend rest API doesn't return the right suspension status on a DAG with custom name. Furthermore, the scheduler also assumes a DAG's "name" is always the filename when calling `client.IsSuspended()`. So I fixed those as well.

It looks like `DAG.Name` is used quite a few times when actually a `DAG.ID` should be used instead. Maybe we should consider adding a new `ID` field to the `DAG` struct, which always stores the YAML filename, while `DAG.Name` can be overwritten with a custom name from the DAG spec.