### PR TITLE
refactor: improve the pattern of "schedule" in the JSON schema file

### DIFF
--- a/schemas/dag.schema.json
+++ b/schemas/dag.schema.json
@@ -13,7 +13,7 @@
     },
     "schedule": {
       "type": "string",
-      "pattern": "^[0-9* ]+$",
+      "pattern": "(\\*|[0-5]?[0-9]|\\*\/[0-9]+)\\s+(\\*|1?[0-9]|2[0-3]|\\*\/[0-9]+)\\s+(\\*|[1-2]?[0-9]|3[0-1]|\\*\/[0-9]+)\\s+(\\*|[0-9]|1[0-2]|\\*\/[0-9]+|jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)\\s+(\\*\/[0-9]+|\\*|[0-7]|sun|mon|tue|wed|thu|fri|sat)\\s*(\\*\/[0-9]+|\\*|[0-9]+)?",
       "description": "Cron schedule expression for the DAG"
     },
     "group": {
@@ -43,7 +43,7 @@
       "description": "Seconds to wait before restarting DAG process"
     },
     "histRetentionDays": {
-      "type": "integer", 
+      "type": "integer",
       "description": "Days to retain execution history"
     },
     "delaySec": {
@@ -75,7 +75,7 @@
         }
       },
       "description": "List of conditions to check before running DAG/step"
-    },  
+    },
     "mailOn": {
       "type": "object",
       "properties": {
@@ -117,7 +117,7 @@
             "command": {
               "type": "string"
             }
-          }  
+          }
         },
         "exit": {
           "type": "object",
@@ -147,7 +147,7 @@
             "description": "List of step names this step depends on"
           },
           "description": {
-            "type": "string" 
+            "type": "string"
           },
           "dir": {
             "type": "string"
@@ -187,7 +187,7 @@
               "skipped": {
                 "type": "boolean"
               }
-            }  
+            }
           },
           "retryPolicy": {
             "type": "object",


### PR DESCRIPTION
The current JSON schema of DAGs doesn't support cron expressions well on the `schedule` field. This PR improves that. The cron pattern is copied from https://github.com/MediaMath/lambda-cron/blob/master/lambda_cron/schema.json#L11.

Before:

<img width="893" alt="Screenshot 2024-07-29 at 10 41 15 PM" src="https://github.com/user-attachments/assets/a90e8771-e96a-417e-8b2b-301f5c659386">

After: No more wiggly lines.

<img width="355" alt="Screenshot 2024-07-29 at 10 42 16 PM" src="https://github.com/user-attachments/assets/fb9d5643-d96b-4d33-95b6-579332dd8021">

See also https://github.com/daguflow/dagu/issues/325
