### PR TITLE
Fix log not loading when '&' in name

### DIFF
--- a/ui/src/components/molecules/NodeStatusTableRow.tsx
+++ b/ui/src/components/molecules/NodeStatusTableRow.tsx
@@ -22,7 +22,7 @@ function NodeStatusTableRow({
   file,
   onRequireModal,
 }: Props) {
-  const url = `/dags/${name}/log?file=${file}&step=${node.Step.Name}`;
+  const url = `/dags/${name}/log?file=${file}&step=${encodeURIComponent(node.Step.Name)}`;
   const buttonStyle = {
     margin: '0px',
     padding: '0px',


### PR DESCRIPTION
Fixes an issue where if a step has the '&' character in its name, the step log will not load.