### PR TITLE
ISSUE[578] Add json bool configuration option to HTTP executor

### DIFF
--- a/internal/dag/executor/http.go
+++ b/internal/dag/executor/http.go
@@ -49,7 +49,7 @@ type httpConfig struct {
 	Json    bool              `json:"json"`
 }
 
-type HttpJSONResult struct {
+type httpJSONResult struct {
 	StatusCode int                 `json:"status_code"`
 	Headers    map[string][]string `json:"headers"`
 	Body       map[string]any      `json:"body"`
@@ -117,21 +117,21 @@ var errHTTPStatusCode = errors.New("http status code not 2xx")
 
 func (e *http) writeJSONResult(rsp *resty.Response) error {
 	var (
-		httpJSONResult      = &HttpJSONResult{}
+		httpJSONResultData  = &httpJSONResult{}
 		err                 error
 		httpJSONResultBytes []byte
 	)
 
 	if !rsp.IsSuccess() || !e.cfg.Silent {
-		httpJSONResult.Headers = rsp.Header()
-		httpJSONResult.StatusCode = rsp.StatusCode()
+		httpJSONResultData.Headers = rsp.Header()
+		httpJSONResultData.StatusCode = rsp.StatusCode()
 	}
 
-	if err = json.Unmarshal(rsp.Body(), &httpJSONResult.Body); err != nil {
+	if err = json.Unmarshal(rsp.Body(), &httpJSONResultData.Body); err != nil {
 		return err
 	}
 
-	if httpJSONResultBytes, err = json.MarshalIndent(httpJSONResult, "", " "); err != nil {
+	if httpJSONResultBytes, err = json.MarshalIndent(httpJSONResultData, "", " "); err != nil {
 		return err
 	}
 

--- a/internal/dag/executor/http.go
+++ b/internal/dag/executor/http.go
@@ -46,6 +46,13 @@ type httpConfig struct {
 	Body    string            `json:"body"`
 	Silent  bool              `json:"silent"`
 	Debug   bool              `json:"debug"`
+	Json    bool              `json:"json"`
+}
+
+type HttpJSONResult struct {
+	StatusCode int                 `json:"status_code"`
+	Headers    map[string][]string `json:"headers"`
+	Body       map[string]any      `json:"body"`
 }
 
 func newHTTP(ctx context.Context, step dag.Step) (Executor, error) {
@@ -108,15 +115,35 @@ func (e *http) Kill(_ os.Signal) error {
 
 var errHTTPStatusCode = errors.New("http status code not 2xx")
 
-func (e *http) Run() error {
-	rsp, err := e.req.Execute(strings.ToUpper(e.method), e.url)
-	if err != nil {
+func (e *http) writeJSONResult(rsp *resty.Response) error {
+	var (
+		httpJSONResult      = &HttpJSONResult{}
+		err                 error
+		httpJSONResultBytes []byte
+	)
+
+	if !rsp.IsSuccess() || !e.cfg.Silent {
+		httpJSONResult.Headers = rsp.Header()
+		httpJSONResult.StatusCode = rsp.StatusCode()
+	}
+
+	if err = json.Unmarshal(rsp.Body(), &httpJSONResult.Body); err != nil {
 		return err
 	}
 
-	resCode := rsp.StatusCode()
-	isErr := resCode < 200 || resCode > 299
-	if isErr || !e.cfg.Silent {
+	if httpJSONResultBytes, err = json.MarshalIndent(httpJSONResult, "", " "); err != nil {
+		return err
+	}
+
+	if _, err = e.stdout.Write(httpJSONResultBytes); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (e *http) writeTextResult(rsp *resty.Response) error {
+	if !rsp.IsSuccess() || !e.cfg.Silent {
 		if _, err := e.stdout.Write([]byte(rsp.Status() + "\n")); err != nil {
 			return err
 		}
@@ -124,10 +151,33 @@ func (e *http) Run() error {
 			return err
 		}
 	}
+
 	if _, err := e.stdout.Write(rsp.Body()); err != nil {
 		return err
 	}
-	if isErr {
+
+	return nil
+}
+
+func (e *http) Run() error {
+	rsp, err := e.req.Execute(strings.ToUpper(e.method), e.url)
+	if err != nil {
+		return err
+	}
+
+	resCode := rsp.StatusCode()
+
+	if e.cfg.Json {
+		if err = e.writeJSONResult(rsp); err != nil {
+			return err
+		}
+	} else {
+		if err = e.writeTextResult(rsp); err != nil {
+			return err
+		}
+	}
+
+	if !rsp.IsSuccess() {
 		return fmt.Errorf("%w: %d", errHTTPStatusCode, resCode)
 	}
 	return nil

--- a/internal/dag/executor/http.go
+++ b/internal/dag/executor/http.go
@@ -52,7 +52,7 @@ type httpConfig struct {
 type httpJSONResult struct {
 	StatusCode int                 `json:"status_code"`
 	Headers    map[string][]string `json:"headers"`
-	Body       map[string]any      `json:"body"`
+	Body       any                 `json:"body"`
 }
 
 func newHTTP(ctx context.Context, step dag.Step) (Executor, error) {


### PR DESCRIPTION
HTTP executor supports writing the HTTP response in JSON format.
```
{
  "status_code": 200,
  "headers": [
    "xxx": "yyy"
  ],
  "body": {
    "some_field": "some_value"
  }
}
```
HTTP executor config
![image](https://github.com/user-attachments/assets/0aea7a30-80ca-41ff-b6d3-963acc2c9408)
Result
![image](https://github.com/user-attachments/assets/da6aacf5-a018-4569-82aa-04e57f476c5e)
![image](https://github.com/user-attachments/assets/b2a39954-bc9e-4885-af12-91d55fdd7e67)
![image](https://github.com/user-attachments/assets/a14bb4bb-c0d6-44fd-bf08-3b86dabb539f)
![image](https://github.com/user-attachments/assets/08802495-100f-4f46-a6ae-8685247613bd)
