### PR TITLE
[ISSUE 657] Fix HTTP_HandleCancel in TestAgent_HandleHTTP was a flakey test

### DIFF
--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -372,7 +372,7 @@ func TestAgent_HandleHTTP(t *testing.T) {
 			status, err := cli.GetLatestStatus(workflow)
 			require.NoError(t, err)
 			return status.Status == scheduler.StatusCancel
-		}, time.Second*2, time.Millisecond*100)
+		}, time.Second*3, time.Millisecond*100)
 	})
 }
 


### PR DESCRIPTION
Fixes: #657 