### PR TITLE
[ISSUE 565] Implement Timeout Configuration for DAG Tasks

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -339,6 +339,7 @@ func (a *Agent) newScheduler() *scheduler.Scheduler {
 		LogDir:        a.logDir,
 		Logger:        a.logger,
 		MaxActiveRuns: a.dag.MaxActiveRuns,
+		Timeout:       a.dag.Timeout,
 		Delay:         a.dag.Delay,
 		Dry:           a.dry,
 		ReqID:         a.requestID,

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -139,6 +139,20 @@ func TestAgent_Run(t *testing.T) {
 		// Check if the status is saved correctly
 		require.Equal(t, scheduler.StatusError, agt.Status().Status)
 	})
+	t.Run("FinishWithTimeout", func(t *testing.T) {
+		setup := test.SetupTest(t)
+		defer setup.Cleanup()
+
+		// Run a DAG that timeout
+		timeoutDAG := testLoadDAG(t, "timeout.yaml")
+		agt := newAgent(setup, genRequestID(), timeoutDAG, &agent.Options{})
+		ctx := context.Background()
+		err := agt.Run(ctx)
+		require.Error(t, err)
+
+		// Check if the status is saved correctly
+		require.Equal(t, scheduler.StatusError, agt.Status().Status)
+	})
 	t.Run("ReceiveSignal", func(t *testing.T) {
 		setup := test.SetupTest(t)
 		defer setup.Cleanup()

--- a/internal/agent/testdata/timeout.yaml
+++ b/internal/agent/testdata/timeout.yaml
@@ -1,0 +1,6 @@
+timeout: 2
+steps:
+  - name: "1"
+    command: "sleep 1"
+  - name: "2"
+    command: "sleep 2"

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -126,6 +126,7 @@ func (b *builder) build(def *definition, envs []string) (*DAG, error) {
 		Name:        def.Name,
 		Group:       def.Group,
 		Description: def.Description,
+		Timeout:     time.Second * time.Duration(def.Timeout),
 		Delay:       time.Second * time.Duration(def.DelaySec),
 		RestartWait: time.Second * time.Duration(def.RestartWaitSec),
 		Tags:        parseTags(def.Tags),

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -86,6 +86,8 @@ type DAG struct {
 	// MailOn contains the conditions to send mail.
 	MailOn *MailOn `json:"MailOn"`
 
+	// Timeout is a field to specify the maximum execution time of the DAG task
+	Timeout time.Duration `json:"Timeout"`
 	// Misc configuration for DAG execution.
 	// Delay is the delay before starting the DAG.
 	Delay time.Duration `json:"Delay"`

--- a/internal/dag/definition.go
+++ b/internal/dag/definition.go
@@ -32,6 +32,7 @@ type definition struct {
 	MailOn            *mailOnDef
 	ErrorMail         mailConfigDef
 	InfoMail          mailConfigDef
+	Timeout           int
 	DelaySec          int
 	RestartWaitSec    int
 	HistRetentionDays *int


### PR DESCRIPTION
Fixes: #565 

Modified to allow timeouts to be set for DAG task execution.

- As outlined in issue #565, when a timeout occurs, all steps are set to cancel status and the entire DAG is set to error status (failed).
![localhost_8080_dags_test2_spec (1)](https://github.com/user-attachments/assets/ecb23b3c-c9dd-4f96-a0fc-d841009fb935)

- Output to the log to indicate that a step has been canceled.
```
time=2024-08-11T14:41:08.210+09:00 level=INFO msg="Workflow execution initiated" workflow=test2 requestID=0553ba38-1861-4a35-a0c5-5a9196e6f1ca logFile=/Users/kiyofumi.sano/.dagu/logs/start_test2.20240811.14:41:08.210.0553ba38.log
time=2024-08-11T14:41:08.213+09:00 level=INFO msg="Step execution started" step=step1
time=2024-08-11T14:41:08.214+09:00 level=INFO msg="Step execution started" step=step4
time=2024-08-11T14:41:08.214+09:00 level=INFO msg="Step execution started" step=step5
time=2024-08-11T14:41:09.231+09:00 level=INFO msg="Step execution finished" step=step1 status=finished
time=2024-08-11T14:41:09.324+09:00 level=INFO msg="Step execution started" step=step2
time=2024-08-11T14:41:09.324+09:00 level=INFO msg="Step execution started" step=step6
time=2024-08-11T14:41:10.215+09:00 level=INFO msg="Step execution deadline exceeded" step=step4 error="signal: killed"
time=2024-08-11T14:41:10.215+09:00 level=INFO msg="Step execution deadline exceeded" step=step6 error="signal: killed"
time=2024-08-11T14:41:10.215+09:00 level=INFO msg="Step execution deadline exceeded" step=step2 error="signal: killed"
time=2024-08-11T14:41:10.215+09:00 level=INFO msg="Step execution deadline exceeded" step=step5 error="signal: killed"
time=2024-08-11T14:41:10.216+09:00 level=INFO msg="Step execution finished" step=step4 status=canceled
time=2024-08-11T14:41:10.220+09:00 level=INFO msg="Step execution finished" step=step6 status=canceled
time=2024-08-11T14:41:10.224+09:00 level=INFO msg="Step execution finished" step=step2 status=canceled
time=2024-08-11T14:41:10.227+09:00 level=INFO msg="Step execution finished" step=step5 status=canceled
time=2024-08-11T14:41:10.334+09:00 level=INFO msg="Workflow execution finished" status=failed

Summary ->
+--------------------------------------+-------+---------------------------+---------------------------+--------+--------+----------------+
| REQUESTID                            | NAME  | STARTED AT                | FINISHED AT               | STATUS | PARAMS | ERROR          |
+--------------------------------------+-------+---------------------------+---------------------------+--------+--------+----------------+
| 0553ba38-1861-4a35-a0c5-5a9196e6f1ca | test2 | 2024-08-11T14:41:08+09:00 | 2024-08-11T14:41:10+09:00 | failed |        | signal: killed |
+--------------------------------------+-------+---------------------------+---------------------------+--------+--------+----------------+
Details ->
+---+-------+---------------------------+---------------------------+----------+----------+----------------+
| # | STEP  | STARTED AT                | FINISHED AT               | STATUS   | COMMAND  | ERROR          |
+---+-------+---------------------------+---------------------------+----------+----------+----------------+
| 1 | step1 | 2024-08-11T14:41:08+09:00 | 2024-08-11T14:41:09+09:00 | finished | sleep 1  |                |
| 2 | step2 | 2024-08-11T14:41:09+09:00 | 2024-08-11T14:41:10+09:00 | canceled | sleep 10 | signal: killed |
| 3 | step3 | -                         | -                         | canceled | sleep5   |                |
| 4 | step4 | 2024-08-11T14:41:08+09:00 | 2024-08-11T14:41:10+09:00 | canceled | sleep 4  | signal: killed |
| 5 | step5 | 2024-08-11T14:41:08+09:00 | 2024-08-11T14:41:10+09:00 | canceled | sleep 5  | signal: killed |
| 6 | step6 | 2024-08-11T14:41:09+09:00 | 2024-08-11T14:41:10+09:00 | canceled | sleep 1  | signal: killed |
+---+-------+---------------------------+---------------------------+----------+----------+----------------+time=2024-08-11T14:41:10.343+09:00 level=ERROR msg="Workflow execution failed" error="signal: killed" workflow=test2 requestID=0553ba38-1861-4a35-a0c5-5a9196e6f1ca
```