### PR TITLE
[ISSUE #592] formatting of error text in web ui is not very noticeable

### DIFF
--- a/ui/src/components/molecules/DAGErrorSnackBar.tsx
+++ b/ui/src/components/molecules/DAGErrorSnackBar.tsx
@@ -1,0 +1,71 @@
+import { Alert, AlertTitle, Box, Snackbar} from "@mui/material";
+import React from "react";
+
+type DAGErrorSnackBarProps = {
+    open: boolean;
+    setOpen: (open: boolean) => void;
+    errors: string[];
+};
+
+const DAGErrorSnackBar = ({ open, setOpen, errors }: DAGErrorSnackBarProps) => {
+    const handleClose = () => {
+        setOpen(false);
+    };
+
+    return (
+        <Snackbar
+            anchorOrigin={{
+                vertical: 'top',
+                horizontal: 'center',
+            }}
+            security="error"
+            open={open}
+            autoHideDuration={6000}
+            onClose={handleClose}
+        >
+            <Alert
+                severity="error"
+                sx={{
+                    width: '20vw',
+                }}
+                onClose={handleClose}
+            >
+                <Box
+                    sx={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        alignItems: 'center',
+                    }}
+                >
+                    <AlertTitle
+                        sx={{
+                            color: '#FF4D4D',
+                            fontSize: '1.5rem',
+                        }}
+                    >Error Detected</AlertTitle>
+                    <Box
+                        sx={{
+                            color: '#FC7E7E',
+                            fontSize: '1.2rem',
+                        }}
+                    >
+                        Please check the following errors:
+                    </Box>
+                    {errors.map((error, index) => (
+                        <Box key={index}
+                            sx={{
+                                color: '#FC7E7E',
+                                fontSize: '1rem',
+                                margin: '2px',
+                            }}
+                        >
+                            {error}
+                        </Box>
+                    ))}
+                </Box>
+            </Alert>
+        </Snackbar>
+    );
+}
+
+export default DAGErrorSnackBar;

--- a/ui/src/pages/dags/dag/index.tsx
+++ b/ui/src/pages/dags/dag/index.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo } from 'react';
 import { Link, useParams, useLocation } from 'react-router-dom';
 import { GetDAGResponse } from '../../../models/api';
-import DAGSpecErrors from '../../../components/molecules/DAGSpecErrors';
 import DAGStatus from '../../../components/organizations/DAGStatus';
 import { DAGContext } from '../../../contexts/DAGContext';
 import DAGSpec from '../../../components/organizations/DAGSpec';
@@ -14,6 +13,7 @@ import DAGEditButtons from '../../../components/molecules/DAGEditButtons';
 import LoadingIndicator from '../../../components/atoms/LoadingIndicator';
 import { AppBarContext } from '../../../contexts/AppBarContext';
 import useSWR from 'swr';
+import DAGErrorSnackBar from '../../../components/molecules/DAGErrorSnackBar';
 
 type Params = {
   name: string;
@@ -24,6 +24,7 @@ function DAGDetails() {
   const params = useParams<Params>();
   const appBarContext = React.useContext(AppBarContext);
   const { pathname } = useLocation();
+  const [open, setOpen] = React.useState(true);
 
   const baseUrl = useMemo(
     () => `/dags/${encodeURI(params.name!)}`,
@@ -46,6 +47,9 @@ function DAGDetails() {
   React.useEffect(() => {
     if (data) {
       appBarContext.setTitle(data.Title);
+    }
+    if (data && data.Errors.length > 0 && params.tab == 'spec') {
+      setOpen(true);
     }
   }, [data, appBarContext]);
 
@@ -112,9 +116,11 @@ function DAGDetails() {
           ) : null}
         </Stack>
 
-        <Box sx={{ mt: 2, mx: 4 }}>
-          <DAGSpecErrors errors={data.Errors} />
-        </Box>
+        <DAGErrorSnackBar
+            open={open}
+            setOpen={setOpen}
+            errors={data.Errors}
+          />
 
         <Box sx={{ mx: 4, flex: 1 }}>
           {tab == 'status' ? (


### PR DESCRIPTION
1. make error text more noticeable
like :
![image](https://github.com/user-attachments/assets/574f1fe8-6a6b-41c0-9f80-71496193ceee)
